### PR TITLE
bug in converting vertical slit data

### DIFF
--- a/arpes/utilities/conversion/kx_ky_conversion.py
+++ b/arpes/utilities/conversion/kx_ky_conversion.py
@@ -241,6 +241,7 @@ class ConvertKxKy(CoordinateConverter):
         if self.is_slit_vertical:
             # phi actually measures along ky
             ky_angle, kx_angle = kx_angle, ky_angle
+            ((ky_low, ky_high), (kx_low, kx_high)) = ((kx_low, kx_high), (ky_low, ky_high))
 
         len_ky_angle = len(self.arr.coords[ky_angle])
         len_kx_angle = len(self.arr.coords[kx_angle])


### PR DESCRIPTION
After converting one data whose slit is vertical, grid spectrum data doesn't match coords('kx', 'ky') calculated from "calculate_kx_ky_bounds".  Because coords('kx', 'ky') are calculated in horizontal slit.  We should change them before "np.arange"(line265 to line270).