### PR TITLE
Initial work on slimming down installations. This consists of

### DIFF
--- a/arpes/analysis/decomposition.py
+++ b/arpes/analysis/decomposition.py
@@ -1,5 +1,6 @@
 """Provides array decomposition approaches like principal component analysis for xarray types."""
 from functools import wraps
+from arpes.feature_gate import Gates, gate
 
 from arpes.provenance import provenance
 from arpes.typing import DataType
@@ -15,6 +16,7 @@ __all__ = (
 )
 
 
+@gate(Gates.ML)
 def decomposition_along(
     data: DataType, axes: List[str], decomposition_cls, correlation=False, **kwargs
 ) -> Tuple[DataType, Any]:
@@ -103,6 +105,7 @@ def decomposition_along(
     return into, decomp
 
 
+@gate(Gates.ML)
 @wraps(decomposition_along)
 def pca_along(*args, **kwargs):
     """Specializes `decomposition_along` with `sklearn.decomposition.PCA`."""
@@ -111,6 +114,7 @@ def pca_along(*args, **kwargs):
     return decomposition_along(*args, **kwargs, decomposition_cls=PCA)
 
 
+@gate(Gates.ML)
 @wraps(decomposition_along)
 def factor_analysis_along(*args, **kwargs):
     """Specializes `decomposition_along` with `sklearn.decomposition.FactorAnalysis`."""
@@ -119,6 +123,7 @@ def factor_analysis_along(*args, **kwargs):
     return decomposition_along(*args, **kwargs, decomposition_cls=FactorAnalysis)
 
 
+@gate(Gates.ML)
 @wraps(decomposition_along)
 def ica_along(*args, **kwargs):
     """Specializes `decomposition_along` with `sklearn.decomposition.FastICA`."""
@@ -127,6 +132,7 @@ def ica_along(*args, **kwargs):
     return decomposition_along(*args, **kwargs, decomposition_cls=FastICA)
 
 
+@gate(Gates.ML)
 @wraps(decomposition_along)
 def nmf_along(*args, **kwargs):
     """Specializes `decomposition_along` with `sklearn.decomposition.NMF`."""

--- a/arpes/analysis/pocket.py
+++ b/arpes/analysis/pocket.py
@@ -1,6 +1,5 @@
 """Contains electron/hole pocket analysis routines."""
 import numpy as np
-from sklearn.decomposition import PCA
 
 import xarray as xr
 from arpes.fits.fit_models import AffineBackgroundModel, LorentzianModel
@@ -8,6 +7,7 @@ from arpes.provenance import update_provenance
 from arpes.typing import DataType
 from arpes.utilities import normalize_to_spectrum
 from arpes.utilities.conversion import slice_along_path
+from arpes.feature_gate import gate, Gates
 
 from typing import List, Tuple
 
@@ -19,6 +19,7 @@ __all__ = (
 )
 
 
+@gate(Gates.ML)
 def pocket_parameters(data: DataType, kf_method=None, sel=None, method_kwargs=None, **kwargs):
     """Estimates pocket center, anisotropy, principal vectors, and extent in either angle or k-space.
 
@@ -35,6 +36,8 @@ def pocket_parameters(data: DataType, kf_method=None, sel=None, method_kwargs=No
     Returns:
         Extracted asymmetry parameters.
     """
+    from sklearn.decomposition import PCA
+
     slices, _ = curves_along_pocket(data, **kwargs)  # slices, angles =
 
     if kf_method is None:

--- a/arpes/analysis/self_energy.py
+++ b/arpes/analysis/self_energy.py
@@ -1,4 +1,5 @@
 """Contains self-energy analysis routines."""
+from arpes.feature_gate import Gates, gate
 import xarray as xr
 import lmfit as lf
 import numpy as np
@@ -69,6 +70,9 @@ def local_fermi_velocity(bare_band: xr.DataArray):
         raw_velocity = 1 / raw_velocity
 
     return raw_velocity * METERS_PER_SECOND_PER_EV_ANGSTROM
+
+
+gate(Gates.ML)
 
 
 def estimate_bare_band(dispersion: xr.DataArray, bare_band_specification: Optional[str] = None):

--- a/arpes/feature_gate.py
+++ b/arpes/feature_gate.py
@@ -1,0 +1,149 @@
+"""Implements feature gates so that we can support optional dependencies better.
+
+The way this works is more or less by testing if functionality is available 
+at runtime by attempting an import. Sometimes, we may also perform more checks.
+
+Then, we provide a decorator which provides helpful error messages
+if a feature gate is not passed.
+
+These gates are also used in import time in the `.all` modules in order to 
+control what gets imported when a user requests `arpes.all`.
+"""
+
+import importlib
+import enum
+import functools
+import warnings
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+__all__ = ["gate", "Gates", "failing_feature_gates"]
+
+
+class Gates(str, enum.Enum):
+    LegacyUI = "legacy_ui"
+    ML = "ml"
+    Igor = "igor"
+    Qt = "qt"
+
+
+@dataclass
+class Gate:
+    @property
+    def message(self) -> str:
+        raise NotImplementedError()
+
+    def check(self) -> bool:
+        raise NotImplementedError
+
+    @staticmethod
+    def can_import_module(module_name) -> bool:
+        try:
+            importlib.import_module(module_name)
+            return True
+        except ImportError:
+            return False
+
+
+@dataclass
+class ImportModuleGate(Gate):
+    module_name: str
+    module_install_name: str
+
+    _already_checked_gate: bool = False
+    _gate_did_pass: bool = False
+
+    @property
+    def message(self) -> str:
+        return f"pip install {self.module_install_name}"
+
+    def check(self) -> bool:
+        if not self._already_checked_gate:
+            self._already_checked_gate = True
+            self._gate_did_pass = self.can_import_module(self.module_name)
+
+        return self._gate_did_pass
+
+
+@dataclass
+class ExtrasGate(Gate):
+    name: str
+    module_names: List[str] = field(default_factory=list)
+    module_install_names: List[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        assert len(self.names) == len(self.module_names)
+
+    @property
+    def message(self) -> str:
+        return (
+            f"pip install arpes[{self.name}] OR pip install {' '.join(self.module_install_names)}"
+        )
+
+    def check(self) -> bool:
+        if not self._already_checked_gate:
+            self._already_checked_gate = True
+            self._gate_did_pass = all(self.can_import_module(name) for name in self.module_names)
+
+        return self._gate_did_pass
+
+
+ALL_GATES = {
+    Gates.LegacyUI: [
+        ExtrasGate("legacy_ui", ["bokeh"], ["bokeh"]),
+    ],
+    Gates.ML: [
+        ExtrasGate(
+            "ml", ["skimage", "sklearn", "cvxpy"], ["scikit-image", "scikit-learn", "cvxpy"]
+        ),
+    ],
+    Gates.Qt: [
+        ExtrasGate("qt", ["pyqtgraph"], ["pyqtgraph"]),
+    ],
+    Gates.Igor: [
+        ImportModuleGate("igor", "https://github.com/chstan/igorpy/tarball/712a4c4#egg=igor"),
+    ],
+}
+
+FAILED_GATE_MESSAGE = """
+You need to install some packages before using this PyARPES functionality:
+
+{messages}
+"""
+
+
+def failing_feature_gates(gate_name) -> Optional[List[Gate]]:
+    """
+    Determines whether a given feature should be turned on according to
+    whether appropriate modules are installed and available. If not, we provide
+    detailed instructions in order to instruct the user.
+    """
+
+    failing_gates = []
+    for element in ALL_GATES[gate_name]:
+        if not element.check():
+            failing_gates.append(element)
+
+    if failing_gates:
+        warnings.warn(
+            FAILED_GATE_MESSAGE.format(messages=" - " + "\n - ".join(failing_gates.message))
+        )
+
+    return failing_gates
+
+
+def gate(gate_name: Gates):
+    def decorate_inner(fn):
+        @functools.wraps(fn)
+        def wrapped_fn(*args, **kwargs):
+            if failing_feature_gates(gate_name):
+                raise RuntimeError(
+                    "Cannot run function due to missing features. Please read instructions above."
+                )
+
+            return fn(*args, **kwargs)
+
+        return wrapped_fn
+
+    return decorate_inner

--- a/arpes/io.py
+++ b/arpes/io.py
@@ -79,13 +79,20 @@ def load_data(
     return load_scan(desc, **kwargs)
 
 
-DATA_EXAMPLES = {
-    "cut": ("ALG-MC", "cut.fits"),
-    "map": ("example_data", "fermi_surface.nc"),
-    "photon_energy": ("example_data", "photon_energy.nc"),
-    "nano_xps": ("example_data", "nano_xps.nc"),
-    "temperature_dependence": ("example_data", "temperature_dependence.nc"),
-}
+@dataclass
+class DataExampleReference:
+    name: str
+    location: str = "example_data"
+
+
+DATA_EXAMPLES = [
+    DataExampleReference(name="cut", location="ALG-MC"),
+    DataExampleReference(name="map"),
+    DataExampleReference(name="photon_energy"),
+    DataExampleReference(name="nano_xps"),
+    DataExampleReference(name="temperature_dependence"),
+]
+DATA_EXAMPLES = {example.name: example for example in DATA_EXAMPLES}
 
 
 def load_example_data(example_name="cut") -> xr.Dataset:
@@ -94,10 +101,11 @@ def load_example_data(example_name="cut") -> xr.Dataset:
         warnings.warn(
             f"Could not find requested example_name: {example_name}. Please provide one of {list(DATA_EXAMPLES.keys())}"
         )
+        raise ValueError(f"No requested example {example_name}")
 
-    location, example = DATA_EXAMPLES[example_name]
-    file = Path(__file__).parent / "example_data" / example
-    return load_data(file=file, location=location)
+    example = DATA_EXAMPLES[example_name]
+    file = Path(__file__).parent / "example_data" / example.name
+    return load_data(file=file, location=example.location)
 
 
 @dataclass

--- a/arpes/plotting/all.py
+++ b/arpes/plotting/all.py
@@ -1,4 +1,5 @@
 """Import many useful standard tools."""
+from arpes.feature_gate import Gates, failing_feature_gates
 from .annotations import *
 
 from .bands import *
@@ -20,15 +21,19 @@ from .movie import *
 # Note, we lift Bokeh imports into definitions in case people don't want to install Bokeh
 # and also because of an undesirable interaction between pytest and Bokeh due to Bokeh's use
 # of jinja2.
-from .interactive import *
-from .band_tool import *
-from .comparison_tool import *
-from .curvature_tool import *
-from .fit_inspection_tool import *
-from .mask_tool import *
-from .path_tool import *
-from .dyn_tool import *
-from .qt_tool import qt_tool
-from .qt_ktool import ktool
+if not failing_feature_gates(Gates.LegacyUI):
+    from .interactive import *
+    from .band_tool import *
+    from .comparison_tool import *
+    from .curvature_tool import *
+    from .fit_inspection_tool import *
+    from .mask_tool import *
+    from .path_tool import *
+    from .dyn_tool import *
+
+if not failing_feature_gates(Gates.Qt):
+    from .qt_tool import qt_tool
+    from .qt_ktool import ktool
+    from .fit_tool import *
 
 from .utils import savefig, remove_colorbars, fancy_labels

--- a/arpes/plotting/band_tool.py
+++ b/arpes/plotting/band_tool.py
@@ -1,8 +1,8 @@
 """An interactive band selection tool used to initialize curve fits."""
-import numpy as np
-from bokeh import events
 
+import numpy as np
 import xarray as xr
+
 from arpes.analysis.band_analysis import fit_patterned_bands
 from arpes.exceptions import AnalysisError
 from arpes.models import band
@@ -35,6 +35,7 @@ class BandTool(SaveableTool, CursorTool):
         from bokeh.models.mappers import LinearColorMapper
         from bokeh.models import widgets
         from bokeh.plotting import figure
+        from bokeh import events
 
         if len(self.arr.shape) != 2:
             raise AnalysisError("Cannot use the band tool on non image-like spectra")

--- a/arpes/plotting/dynamic_tool.py
+++ b/arpes/plotting/dynamic_tool.py
@@ -19,8 +19,6 @@ from arpes.utilities.ui import (
 
 __all__ = ("make_dynamic",)
 
-qt_info.setup_pyqtgraph()
-
 
 class DynamicToolWindow(SimpleWindow):
     HELP_DIALOG_CLS = BasicHelpDialog
@@ -155,6 +153,7 @@ class DynamicTool(SimpleApp):
 
 def make_dynamic(fn, data):
     """Starts a tool which makes any analysis function dynamic."""
+    qt_info.setup_pyqtgraph()
     tool = DynamicTool(fn)
     tool.set_data(data)
     tool.start()

--- a/arpes/xarray_extensions.py
+++ b/arpes/xarray_extensions.py
@@ -38,6 +38,7 @@ The `.F.` accessor:
 """
 
 import pandas as pd
+from arpes.feature_gate import Gates, gate
 import lmfit
 import arpes
 import contextlib
@@ -904,6 +905,8 @@ class ARPESAccessorBase:
 
         return 10
 
+    gate(Gates.ML)
+
     def find_spectrum_energy_edges(self, indices=False):
         energy_marginal = self._obj.sum([d for d in self._obj.dims if d not in ["eV"]])
 
@@ -924,6 +927,8 @@ class ARPESAccessorBase:
 
         delta = self._obj.G.stride(generic_dim_names=False)
         return edges * delta["eV"] + self._obj.coords["eV"].values[0]
+
+    gate(Gates.ML)
 
     def find_spectrum_angular_edges_full(self, indices=False):
         # as a first pass, we need to find the bottom of the spectrum, we will use this
@@ -1063,6 +1068,8 @@ class ARPESAccessorBase:
         return self._obj.mean(
             [d for d in self._obj.dims if d not in dim_or_dims], keep_attrs=keep_attrs
         )
+
+    gate(Gates.ML)
 
     def find_spectrum_angular_edges(self, indices=False):
         angular_dim = "pixel" if "pixel" in self._obj.dims else "phi"
@@ -1781,6 +1788,7 @@ class ARPESDataArrayAccessor(ARPESAccessorBase):
 
         arpes.plotting.qt_tool.qt_tool(self._obj, detached=detached, **kwargs)
 
+    @gate(Gates.LegacyUI)
     def show_d2(self, **kwargs):
         """Opens the Bokeh based second derivative image tool."""
         from arpes.plotting.all import CurvatureTool
@@ -1788,6 +1796,7 @@ class ARPESDataArrayAccessor(ARPESAccessorBase):
         curve_tool = CurvatureTool(**kwargs)
         return curve_tool.make_tool(self._obj)
 
+    @gate(Gates.LegacyUI)
     def show_band_tool(self, **kwargs):
         """Opens the Bokeh based band placement tool."""
         from arpes.plotting.all import BandTool
@@ -2621,6 +2630,7 @@ class ARPESFitToolsAccessor:
             }
         )
 
+    @gate(Gates.LegacyUI)
     def show(self, detached: bool = False):
         """Opens a Bokeh based interactive fit inspection tool."""
         from arpes.plotting.fit_tool import fit_tool

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,5 @@
+# Containerized versions of PyARPES
+
+Most users should install according to the directions in the documentation. This means using a source install (git followed by editable install with pip) or should install directly from a package manager. It is useful for CI/CD and in cases where installations are to be set up automatically to use containers, however.
+
+If you want to add a container format, put relevant documentation about the build process and any build metadata into a subfolder here.

--- a/containers/fairmat-slim/Dockerfile
+++ b/containers/fairmat-slim/Dockerfile
@@ -1,0 +1,28 @@
+# NOTE, the Docker build context should be set to the repo root
+# not this folder! This means you should build using
+# 
+# docker build -f containers/fairmat-slim/Dockerfile .
+# 
+# or a similar invocation.
+
+FROM continuumio/miniconda3 AS build
+
+COPY containers/fairmat-slim/environment-fairmat-slim.yml . 
+RUN conda env create -f environment-fairmat-slim.yml
+
+RUN conda install -c conda-forge conda-pack
+
+RUN conda-pack -n arpes -o /tmp/env.tar && \
+  mkdir /venv && cd /venv && tar xf /tmp/env.tar && \
+  rm /tmp/env.tar
+
+RUN /venv/bin/conda-unpack
+
+FROM debian:buster AS runtime
+
+COPY --from=build /venv /venv
+
+SHELL ["bin/bash", "-c"]
+
+# just verify there are no major surprises
+ENTRYPOINT source /venv/bin/activate && python -c "from arpes.all import *"

--- a/containers/fairmat-slim/environment-fairmat-slim.yml
+++ b/containers/fairmat-slim/environment-fairmat-slim.yml
@@ -1,6 +1,5 @@
 name: arpes
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.8
@@ -13,7 +12,6 @@ dependencies:
 
   - pint
   - pandas
-
   - numpy>=1.20.0,<2.0.0
   - scipy>=1.6.0,<2.0.0
   - lmfit>=1.0.0,<2.0.0
@@ -39,12 +37,5 @@ dependencies:
       - tqdm
       - rx
       - dill
-      - ase>=3.20.0,<4.0.0
-
-      # documentation dependencies are basically only these
-      - sphinx
-      - sphinxcontrib-restbuilder
-      - sphinx_rtd_theme
-      - nbsphinx
-      - sphinx_copybutton
-      - -e .[core]
+      - ase>=3.17.0,<3.22.0
+      - -e .[slim]

--- a/environment.yml
+++ b/environment.yml
@@ -39,4 +39,4 @@ dependencies:
       - rx
       - dill
       - ase>=3.17.0,<3.22.0
-      - -e .
+      - -e .[all]

--- a/scripts/audit_packages.py
+++ b/scripts/audit_packages.py
@@ -1,0 +1,52 @@
+import json
+import os
+
+from dataclasses import dataclass
+from pathlib import Path
+
+@dataclass
+class Package:
+    name: str
+    size_bytes: int
+
+    @property
+    def size_mb(self):
+        return self.size_bytes // (1024 * 1024)
+
+    @property
+    def size_kb(self):
+        return self.size_bytes // 1024
+
+    @classmethod
+    def conda_installed(cls):
+        prefix = Path(os.getenv("CONDA_PREFIX"))
+        meta_files = list((prefix / "conda-meta").glob("*.json"))
+
+        packages = []
+        for package_meta in meta_files:
+            with open(package_meta, "r") as f:
+                packages.append(Package.from_json(json.load(f)))
+
+        return packages
+    
+    @classmethod 
+    def from_json(cls, json_data):
+        print(json_data.keys())
+        raise ValueError()
+        return cls(
+            name=json_data["name"],
+            size_bytes=json_data["size"],
+        )
+
+
+if __name__ == '__main__':
+    packages = Package.conda_installed()
+    packages_by_size = sorted(packages, key=lambda p: p.size_bytes, reverse=True)
+
+    print(f"Total size: {sum(p.size_bytes for p in packages) // (1024 * 1024)} (MB)")
+    print("\nName" + " " * 20 + "Size (kb)")
+    print("-" * 33)
+
+    for p in packages_by_size:
+        print(f"{p.name}{' ' * (24 - len(p.name))}{p.size_kb}")
+


### PR DESCRIPTION
1. Move example data to a separate data repository and use fetch
   patterns. We still need the support code here but the new repository
   is in place and data migrated.
2. Move features behind feature gates checked at runtime. This has
   enabled moving heavy requirements behind extra requirements flags.
3. Remove really optional things like cvxpy from standard builds.
4. Use conda-pack to uninstall conda after solving the environment
   during Docker builds. This will need to be unified with whatever
   the Ernstorfer group is doing.