### PR TITLE
Calculate kp bounds

### DIFF
--- a/arpes/constants.py
+++ b/arpes/constants.py
@@ -14,15 +14,15 @@ WORK_FUNCTION = 4.3
 METERS_PER_SECOND_PER_EV_ANGSTROM = (
     151927  # converts from eV * angstrom to meters/second velocity units
 )
-HBAR = 1.05 * 10 ** (-34)
-HBAR_PER_EV = 6.582 * 10 ** (
+HBAR = 1.0545718176461565 * 10 ** (-34)
+HBAR_PER_EV = 6.582119569 * 10 ** (
     -16
 )  # gives the energy lifetime relationship via tau = -hbar / np.imag(self_energy)
-BARE_ELECTRON_MASS = 9.109e-31  # kg
+BARE_ELECTRON_MASS = 9.109383701e-31  # kg
 HBAR_SQ_EV_PER_ELECTRON_MASS = 0.475600805657  # hbar^2 / m0 in eV^2 s^2 / kg
 HBAR_SQ_EV_PER_ELECTRON_MASS_ANGSTROM_SQ = 7.619964  # (hbar^2) / (m0 * angstrom ^2) in eV
 
-K_BOLTZMANN_EV_KELVIN = 8.61733e-5  # in units of eV / Kelvin
+K_BOLTZMANN_EV_KELVIN = 8.617333262145178 - 5  # in units of eV / Kelvin
 K_BOLTZMANN_MEV_KELVIN = 1000 * K_BOLTZMANN_EV_KELVIN  # meV / Kelvin
 
 HC = 1239.84172  # in units of eV * nm
@@ -36,8 +36,8 @@ STRAIGHT_TOF_LENGTH = 0.937206
 SPIN_TOF_LENGTH = 1.1456
 DLD_LENGTH = 1.1456  # This isn't correct but it should be a reasonable guess
 
-K_INV_ANGSTROM = 0.5123
-HV_CONVERSION = 3.81
+K_INV_ANGSTROM = 0.5123167219534328
+HV_CONVERSION = 3.814697265625
 
 # TODO these should be migrated into their appropriate loaders
 SPECTROMETER_MC = {

--- a/arpes/utilities/conversion/bounds_calculations.py
+++ b/arpes/utilities/conversion/bounds_calculations.py
@@ -193,7 +193,7 @@ def calculate_kp_bounds(arr: xr.DataArray):
 
     sampled_phi_values = np.array([phi_low, phi_mid, phi_high])
 
-    kinetic_energy = arr.coords["phi"].max()
+    kinetic_energy = arr.coords["eV"].max()
     kps = (
         arpes.constants.K_INV_ANGSTROM
         * np.sqrt(kinetic_energy)

--- a/arpes/utilities/conversion/bounds_calculations.py
+++ b/arpes/utilities/conversion/bounds_calculations.py
@@ -193,7 +193,7 @@ def calculate_kp_bounds(arr: xr.DataArray):
 
     sampled_phi_values = np.array([phi_low, phi_mid, phi_high])
 
-    kinetic_energy = arr.coords["eV"].max()
+    kinetic_energy = arr.coords["eV"].values.max()
     kps = (
         arpes.constants.K_INV_ANGSTROM
         * np.sqrt(kinetic_energy)
@@ -244,7 +244,7 @@ def calculate_kx_ky_bounds(arr: xr.DataArray):
             beta_mid,
         ]
     )
-    kinetic_energy = arr.coords["eV"].max()
+    kinetic_energy = arr.coords["eV"].values.max()
 
     kxs = arpes.constants.K_INV_ANGSTROM * np.sqrt(kinetic_energy) * np.sin(sampled_phi_values)
     kys = (

--- a/arpes/utilities/conversion/bounds_calculations.py
+++ b/arpes/utilities/conversion/bounds_calculations.py
@@ -65,17 +65,17 @@ def full_angles_to_k(kinetic_energy, phi, psi, alpha, beta, theta, chi, inner_po
     vrchi_y = sin_chi * vrbeta_x + cos_chi * vrbeta_y
     vrchi_z = vrbeta_z
 
-    v_par_sq = vrchi_x ** 2 + vrchi_y ** 2
+    v_par_sq = vrchi_x**2 + vrchi_y**2
 
     """
     velocity -> momentum in each of parallel and perpendicular directions
     in the perpendicular case, we need the value of the cos^2(zeta) for the polar declination
     angle zeta in the sample (emission) frame. The total in plane velocity v_parallel is proportional
     to sin(zeta), so by the trig identity:
-    
+
     1 = cos^2(zeta) + sin^2(zeta)
-    
-    we may substitute cos^2(zeta) for 1 - sin^2(zeta) which is 1 - (vrchi_x **2 + vrchi_y ** 2) above.  
+
+    we may substitute cos^2(zeta) for 1 - sin^2(zeta) which is 1 - (vrchi_x **2 + vrchi_y ** 2) above.
     """
     k_par = arpes.constants.K_INV_ANGSTROM * np.sqrt(kinetic_energy)
     k_perp = arpes.constants.K_INV_ANGSTROM * np.sqrt(
@@ -118,7 +118,7 @@ def euler_to_kz(kinetic_energy, phi, beta, theta=0, inner_potential=10, slit_is_
         beta_term = np.cos(phi + theta) * np.cos(beta)
 
     return arpes.constants.K_INV_ANGSTROM * np.sqrt(
-        kinetic_energy * beta_term ** 2 + inner_potential
+        kinetic_energy * beta_term**2 + inner_potential
     )
 
 
@@ -193,7 +193,7 @@ def calculate_kp_bounds(arr: xr.DataArray):
 
     sampled_phi_values = np.array([phi_low, phi_mid, phi_high])
 
-    kinetic_energy = arr.S.hv - arr.S.work_function
+    kinetic_energy = arr.coords["phi"].max()
     kps = (
         arpes.constants.K_INV_ANGSTROM
         * np.sqrt(kinetic_energy)
@@ -244,7 +244,7 @@ def calculate_kx_ky_bounds(arr: xr.DataArray):
             beta_mid,
         ]
     )
-    kinetic_energy = arr.S.hv - arr.S.work_function
+    kinetic_energy = arr.coords["eV"].max()
 
     kxs = arpes.constants.K_INV_ANGSTROM * np.sqrt(kinetic_energy) * np.sin(sampled_phi_values)
     kys = (


### PR DESCRIPTION
I think the kinetic_energy in calculate_kp_bounds should be changed from "kinetic_energy = arr.S.hv - arr.S.work_function"

This is not so suitable for 2PPE experiments. The target energy is about 5 eV above the Fermi level.

And more accurate value about the physical constants are safe.