### PR TITLE
Update ANTARES data loader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,10 @@
+Conrad Stansbury (chstansbury@gmail.com, chstan@berkeley.edu)
+
+## Additional contributors:
+
+danbott (Daniel Eilbott)
+ndale93 (Nicholas Dale)
+rainsty
+kcurrier6
+Tommaso (Tommaso Pincelli)
+cgfatuzzo (Claudia Fatuzzo)

--- a/arpes/endstations/nexus_utils.py
+++ b/arpes/endstations/nexus_utils.py
@@ -3,10 +3,122 @@
 Currently we assume that the raw file format is actually HDF.
 """
 
-from typing import Dict, Any
+import numpy as np
+import h5py as h5
+import xarray as xr
+from dataclasses import dataclass, field
+from typing import Dict, Any, List, Callable
 
 __all__ = ["read_data_attributes_from"]
 
+def read_group_data(group, attribute_name=None) -> Any:
+    if attribute_name is not None:
+        try:
+            data = group[attribute_name]["data"]
+        except ValueError:
+            data = group[attribute_name]
+    else:
+        try: 
+            data = group["data"]
+        except ValueError:
+            data = group
+
+    try:
+        data = data[:]
+    except ValueError:
+        data = data[()]
+
+    if isinstance(data, np.ndarray):
+        try:
+            data = data.item()
+        except ValueError:
+            pass
+
+    return data
+
+@dataclass
+class Target:
+    name: str = ""
+    read: Callable = field(default=lambda x: x)
+
+    value: Any = None
+
+    def read_h5(self, g, path):
+        self.value = None
+        self.value = self.read(read_group_data(g))
+
+    def write_to_dataarray(self, arr: xr.DataArray):
+        pass
+
+    def write_to_dataset(self, dset: xr.Dataset):
+        pass
+
+@dataclass
+class DebugTarget(Target):
+    name = "debug"
+
+    def read_h5(self, g, path):
+        print(path, self.read(read_group_data(g)))
+
+@dataclass
+class AttrTarget(Target):
+    def write_to_dataarray(self, arr: xr.DataArray):
+        arr.attrs[self.name] = self.value
+    
+@dataclass
+class CoordTarget(Target):
+    def write_to_dataarray(self, arr: xr.DataArray):
+        arr.coords[self.name] = self.value
+
+
+def read_data_attributes_from_tree(group, tree, targets=None, path=None) -> List[Target]:
+    """Reads simple (float, string, etc.) leaves from nested paths out of a NeXuS file.
+
+    This is handled in a more robust way because we use two stages
+    to (1) read the attribute data from the file and (2) bind the data
+    we read to the target xr.DataArray and xr.Dataset. 
+
+    Args:
+        group: The NeXuS/HDF Group or File object to read from
+        tree: A binding tree whose leaves are `Target` instances
+
+    Returns:
+        Flat collection of `Target` instances which have been populated
+    """
+
+    if targets is None:
+        targets = []
+    
+    if path is None:
+        path = []
+    
+    if isinstance(tree, Target):
+        tree = [tree]
+
+    if isinstance(tree, (list, tuple)):
+        for t in tree:
+            t.read_h5(group, path)
+            targets.append(t)
+        
+        return targets
+    
+    marked = set()
+    for k, g in group.items():
+        if k in tree:
+            marked.add(k)
+            path.append(k)
+            read_data_attributes_from_tree(g, tree[k], targets, path)
+            path.pop()
+
+    for k, g in group.attrs.items():
+        if k in marked:
+            raise ValueError(f"Already encountered {k}. Skipping")
+        if k in tree and k not in marked:
+            path.append(k)
+            read_data_attributes_from_tree(g, tree[k], targets, path)
+            path.pop()
+
+    return targets
 
 def read_data_attributes_from(group, paths) -> Dict[str, Any]:
     """Reads simple (float, string, etc.) leaves from nested paths out of a NeXuS file.
@@ -26,15 +138,7 @@ def read_data_attributes_from(group, paths) -> Dict[str, Any]:
             group = group[p]
 
         for attribute_name in attributes:
-            try:
-                data = group[attribute_name]["data"]
-            except ValueError:
-                data = group[attribute_name]
-            try:
-                data = data[:]
-            except ValueError:
-                data = data[()]
-
+            data = read_group_data(group, attribute_name)
             read_attrs[attribute_name] = data
 
     return read_attrs

--- a/arpes/endstations/nexus_utils.py
+++ b/arpes/endstations/nexus_utils.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, List, Callable
 
 __all__ = ["read_data_attributes_from"]
 
+
 def read_group_data(group, attribute_name=None) -> Any:
     if attribute_name is not None:
         try:
@@ -18,7 +19,7 @@ def read_group_data(group, attribute_name=None) -> Any:
         except ValueError:
             data = group[attribute_name]
     else:
-        try: 
+        try:
             data = group["data"]
         except ValueError:
             data = group
@@ -35,6 +36,7 @@ def read_group_data(group, attribute_name=None) -> Any:
             pass
 
     return data
+
 
 @dataclass
 class Target:
@@ -53,6 +55,7 @@ class Target:
     def write_to_dataset(self, dset: xr.Dataset):
         pass
 
+
 @dataclass
 class DebugTarget(Target):
     name = "debug"
@@ -60,11 +63,13 @@ class DebugTarget(Target):
     def read_h5(self, g, path):
         print(path, self.read(read_group_data(g)))
 
+
 @dataclass
 class AttrTarget(Target):
     def write_to_dataarray(self, arr: xr.DataArray):
         arr.attrs[self.name] = self.value
-    
+
+
 @dataclass
 class CoordTarget(Target):
     def write_to_dataarray(self, arr: xr.DataArray):
@@ -76,7 +81,7 @@ def read_data_attributes_from_tree(group, tree, targets=None, path=None) -> List
 
     This is handled in a more robust way because we use two stages
     to (1) read the attribute data from the file and (2) bind the data
-    we read to the target xr.DataArray and xr.Dataset. 
+    we read to the target xr.DataArray and xr.Dataset.
 
     Args:
         group: The NeXuS/HDF Group or File object to read from
@@ -88,10 +93,10 @@ def read_data_attributes_from_tree(group, tree, targets=None, path=None) -> List
 
     if targets is None:
         targets = []
-    
+
     if path is None:
         path = []
-    
+
     if isinstance(tree, Target):
         tree = [tree]
 
@@ -99,9 +104,9 @@ def read_data_attributes_from_tree(group, tree, targets=None, path=None) -> List
         for t in tree:
             t.read_h5(group, path)
             targets.append(t)
-        
+
         return targets
-    
+
     marked = set()
     for k, g in group.items():
         if k in tree:
@@ -119,6 +124,7 @@ def read_data_attributes_from_tree(group, tree, targets=None, path=None) -> List
             path.pop()
 
     return targets
+
 
 def read_data_attributes_from(group, paths) -> Dict[str, Any]:
     """Reads simple (float, string, etc.) leaves from nested paths out of a NeXuS file.

--- a/arpes/endstations/plugin/ANTARES.py
+++ b/arpes/endstations/plugin/ANTARES.py
@@ -1,4 +1,5 @@
-"""Implements data loading for ANTARES at SOLEIL."""
+"""implements data loading for ANTARES at SOLEIL."""
+from collections import Counter
 import warnings
 
 import h5py
@@ -6,51 +7,58 @@ import numpy as np
 
 import xarray as xr
 from arpes.endstations import HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstation
-from arpes.endstations.nexus_utils import read_data_attributes_from
+from arpes.endstations.nexus_utils import AttrTarget, CoordTarget, DebugTarget, read_data_attributes_from, read_data_attributes_from_tree
 from arpes.preparation import disambiguate_coordinates
 
 __all__ = ("ANTARESEndstation",)
 
+MONO_READ_TREE = {
+    "energy": CoordTarget("hv"),
+    "exitSlitAperature": AttrTarget("exit_slit_aperature"),
+    "resolution": AttrTarget("resolution"),
+    "currentGratingName": AttrTarget("current_grating_name"),
+    "currentSlotName": AttrTarget("current_slot_name"),
+}
 
-mono = [
-    ["ANTARES", "Monochromator"],
-    ["exitSlitAperture", "resolution", "currentGratingName", "currentSlotName", "energy"],
-]
-user_info = [["User"], ["email", "address", "affiliation", "name", "telephone_number"]]
-misc = [[], ["comment_conditions", "experimental_frame", "start_time"]]
+USER_INFO_READ_TREE = {
+    "email": AttrTarget("user_email"),
+    "address": AttrTarget("user_address"),
+    "affiliation": AttrTarget("user_affiliation"),
+    "name": AttrTarget("user_name"),
+    "telephone_number": AttrTarget("user_telephone_number"),
+}
 
+READ_TREE = {
+    "ANTARES": {
+        "Monochromator": MONO_READ_TREE
+    },
+    "User": USER_INFO_READ_TREE,
+    "comment_conditions": AttrTarget("comment_conditions"),
+    "experimental_frame": AttrTarget("experimental_frame"),
+    "start_time": AttrTarget("start_time"),
+}
 
-general_paths = [mono, user_info, misc]
+MBS_TREE = {
+    "Frames": AttrTarget("frames"),
+    "LensMode": AttrTarget("lens_mode"),
+    "PASSENERGY": AttrTarget("pass_energy"),
+    "DeflX": CoordTarget("psi"),
+    "DeflY": CoordTarget("defl_y"),
+    "CenterKE": AttrTarget("center_ke"),
+    "StepSize": AttrTarget("mbs_step_size"),
+    "StartX": AttrTarget("mbs_start_x"),
+    "StartY": AttrTarget("mbs_start_y"),
+    "EndX": AttrTarget("mbs_end_x"),
+    "EndY": AttrTarget("mbs_end_y"),
+    "StartKE": AttrTarget("mbs_start_ke"),
+    "NoSlices": AttrTarget("mbs_no_slices"),
+    "NoScans": AttrTarget("mbs_no_scans"),
+}
 
-# not generally needed
-mbs_general_location = [[], ["PI-X", "PI-Y", "PI-Z", "Phi", "Theta"]]
-mbs_general_paths = [mbs_general_location]
-
-# To be run inside ANTARES/MBSAcquisition_{idx}
-mbs_acquisition_spectrometer = [
-    [],
-    [
-        "Frames",
-        "LensMode",
-        "PASSENERGY",
-        "DeflX",
-        "DeflY",
-        "CenterKE",
-        "StepSize",
-        "StartX",
-        "StartY",
-        "EndX",
-        "EndY",
-        "StartKE",
-        "NoSlices",
-        "NoScans",
-    ],
-]
-mbs_acquisition_paths = [mbs_acquisition_spectrometer]
-
-
-def parse_axis_name_from_long_name(name):
-    return name.split("/")[-1].replace("'", "")
+def parse_axis_name_from_long_name(name, keep_segments=1, separator="_"):
+    segments = name.split("/")[-keep_segments:]
+    segments = [s.replace("'", "") for s in segments]
+    return separator.join(segments)
 
 
 def infer_scan_type_from_data(group):
@@ -83,29 +91,30 @@ class ANTARESEndstation(HemisphericalEndstation, SynchrotronEndstation, SingleFi
 
     _TOLERATED_EXTENSIONS = {".nxs"}
 
-    RENAME_KEYS = {
-        "DeflX": "psi",
-        "deflx": "psi",
-        "energy": "hv",
-        "PASSENERGY": "pass_energy",
-        "LensMode": "lens_mode",
-    }
+    RENAME_KEYS = {}
 
     def load_top_level_scan(self, group, scan_desc: dict = None, spectrum_index=None):
         """Reads a spectrum from the top level group in a NeXuS scan format."""
         dr = self.read_scan_data(group)
-        attrs = read_data_attributes_from(group, general_paths)
+        bindings = read_data_attributes_from_tree(group, READ_TREE)
+
+        for binding in bindings:
+            binding.write_to_dataarray(dr)
 
         try:
             mbs_key = [k for k in list(group["ANTARES"].keys()) if "MBSAcquisition" in k][0]
-            attrs.update(
-                read_data_attributes_from(group["ANTARES"][mbs_key], mbs_acquisition_paths)
-            )
+            mbs_group = group["ANTARES"][mbs_key]
+            mbs_bindings = read_data_attributes_from_tree(mbs_group, MBS_TREE)
+            bindings.extend(mbs_bindings)
         except IndexError:
             pass
 
-        dr = dr.assign_attrs(attrs)
-        return xr.Dataset(dict([["spectrum-{}".format(spectrum_index), dr]]))
+        ds = xr.Dataset(dict([["spectrum-{}".format(spectrum_index), dr]]))
+
+        for binding in bindings:
+            binding.write_to_dataset(ds)
+
+        return ds
 
     def get_coords(self, group, scan_name, shape):
         """Extracts coordinates from the actuator header information.
@@ -118,10 +127,21 @@ class ANTARESEndstation(HemisphericalEndstation, SynchrotronEndstation, SingleFi
         # handle actuators
         relaxed_shape = list(shape)
         actuator_list = [k for k in list(data.keys()) if "actuator" in k]
-        actuator_names = [
-            parse_axis_name_from_long_name(str(data[act].attrs["long_name"]))
-            for act in actuator_list
-        ]
+        actuator_long_names = [str(data[act].attrs["long_name"]) for act in actuator_list]
+        actuator_names = [parse_axis_name_from_long_name(name) for name in actuator_long_names]
+
+        # This more carefully deduplicates names if they have a common
+        # suffix in the long name format.
+        keep_segments = 1
+        set_names = Counter(actuator_names)
+        while len(set_names) != len(actuator_names):
+            keep_segments += 1
+            actuator_names = [
+                name if set_names[name] == 1 else parse_axis_name_from_long_name(actuator_long_names[i], keep_segments) 
+                for i, name in enumerate(actuator_names)
+            ]
+            set_names = Counter(actuator_names)
+
         actuator_list = [data[act][:] for act in actuator_list]
 
         actuator_dim_order = []
@@ -273,6 +293,12 @@ class ANTARESEndstation(HemisphericalEndstation, SynchrotronEndstation, SingleFi
         for l in ls:
             check_attrs(l)
 
+        # attempt to determine whether the energy is likely a kinetic energy
+        # if so, we will subtract the photon energy
+        if "eV" in data.indexes:
+            mean_energy = data["eV"].values.mean()
+            photon_energy = data.coords.get("hv", 0)
+
         # TODO fix this
         defaults = {
             "z": 0,
@@ -282,7 +308,7 @@ class ANTARESEndstation(HemisphericalEndstation, SynchrotronEndstation, SingleFi
             "chi": 0,
             "theta": 0,
             "beta": 0,
-            "hv": 100,
+            "hv": None,
             "psi": 0,
         }
         for k, v in defaults.items():

--- a/arpes/endstations/plugin/ANTARES.py
+++ b/arpes/endstations/plugin/ANTARES.py
@@ -7,7 +7,13 @@ import numpy as np
 
 import xarray as xr
 from arpes.endstations import HemisphericalEndstation, SingleFileEndstation, SynchrotronEndstation
-from arpes.endstations.nexus_utils import AttrTarget, CoordTarget, DebugTarget, read_data_attributes_from, read_data_attributes_from_tree
+from arpes.endstations.nexus_utils import (
+    AttrTarget,
+    CoordTarget,
+    DebugTarget,
+    read_data_attributes_from,
+    read_data_attributes_from_tree,
+)
 from arpes.preparation import disambiguate_coordinates
 
 __all__ = ("ANTARESEndstation",)
@@ -29,9 +35,7 @@ USER_INFO_READ_TREE = {
 }
 
 READ_TREE = {
-    "ANTARES": {
-        "Monochromator": MONO_READ_TREE
-    },
+    "ANTARES": {"Monochromator": MONO_READ_TREE},
     "User": USER_INFO_READ_TREE,
     "comment_conditions": AttrTarget("comment_conditions"),
     "experimental_frame": AttrTarget("experimental_frame"),
@@ -54,6 +58,7 @@ MBS_TREE = {
     "NoSlices": AttrTarget("mbs_no_slices"),
     "NoScans": AttrTarget("mbs_no_scans"),
 }
+
 
 def parse_axis_name_from_long_name(name, keep_segments=1, separator="_"):
     segments = name.split("/")[-keep_segments:]
@@ -137,7 +142,9 @@ class ANTARESEndstation(HemisphericalEndstation, SynchrotronEndstation, SingleFi
         while len(set_names) != len(actuator_names):
             keep_segments += 1
             actuator_names = [
-                name if set_names[name] == 1 else parse_axis_name_from_long_name(actuator_long_names[i], keep_segments) 
+                name
+                if set_names[name] == 1
+                else parse_axis_name_from_long_name(actuator_long_names[i], keep_segments)
                 for i, name in enumerate(actuator_names)
             ]
             set_names = Counter(actuator_names)

--- a/arpes/plotting/dyn_tool.py
+++ b/arpes/plotting/dyn_tool.py
@@ -238,10 +238,19 @@ class DynamicTool(BokehInteractiveTool, CursorTool):
 
             widget = None
             if specification["type"] == int:
-                widget = widgets.Slider(start=specification["start"], end=specification["end"], value=specification["value"], title=parameter_name)
+                widget = widgets.Slider(
+                    start=specification["start"],
+                    end=specification["end"],
+                    value=specification["value"],
+                    title=parameter_name,
+                )
             if specification["type"] == float:
                 widget = widgets.Slider(
-                    start=specification["start"], end=specification["end"], value=specification["value"], step=specification["step"], title=parameter_name
+                    start=specification["start"],
+                    end=specification["end"],
+                    value=specification["value"],
+                    step=specification["step"],
+                    title=parameter_name,
                 )
 
             if widget is not None:

--- a/arpes/plotting/qt_tool/__init__.py
+++ b/arpes/plotting/qt_tool/__init__.py
@@ -446,7 +446,8 @@ class QtTool(SimpleApp):
         self.configure_image_widgets()
         self.add_contextual_widgets()
         import matplotlib.cm
-        if self.data.min()>=0.0:
+
+        if self.data.min() >= 0.0:
             self.set_colormap(matplotlib.cm.viridis)
         else:
             self.set_colormap(matplotlib.cm.RdBu_r)

--- a/arpes/utilities/qt/app.py
+++ b/arpes/utilities/qt/app.py
@@ -99,7 +99,7 @@ class SimpleApp:
         reasons we want to use the ones from matplotlib. This will sample the colors
         from the colormap and convert it into an array suitable for pyqtgraph.
         """
-        sampling_array=np.linspace(0,1,5)
+        sampling_array = np.linspace(0, 1, 5)
         sampled_colormap = colormap(sampling_array)
 
         # need to scale colors if pyqtgraph is older.

--- a/arpes/utilities/qt/data_array_image_view.py
+++ b/arpes/utilities/qt/data_array_image_view.py
@@ -54,9 +54,13 @@ class DataArrayPlot(pg.PlotWidget):
         self._coord_axis.setImage(data)
 
         if self.orientation == PlotOrientation.Horizontal:
-            return self.plotItem.plot(np.arange(0, len(y)), y, pen=pg.mkPen(color=(68,1,84), width=3), *args, **kwargs)
+            return self.plotItem.plot(
+                np.arange(0, len(y)), y, pen=pg.mkPen(color=(68, 1, 84), width=3), *args, **kwargs
+            )
         else:
-            return self.plotItem.plot(y, np.arange(0, len(y)), pen=pg.mkPen(color=(68,1,84), width=3), *args, **kwargs)
+            return self.plotItem.plot(
+                y, np.arange(0, len(y)), pen=pg.mkPen(color=(68, 1, 84), width=3), *args, **kwargs
+            )
 
 
 class DataArrayImageView(pg.ImageView):

--- a/arpes/utilities/qt/windows.py
+++ b/arpes/utilities/qt/windows.py
@@ -58,7 +58,7 @@ class SimpleWindow(QtWidgets.QMainWindow, QtCore.QObject):
         """Unused hook for supporting additional cursor modes."""
         return []
 
-    def closeEvent(self,event):
+    def closeEvent(self, event):
         self.do_close(event)
 
     def do_close(self, event):


### PR DESCRIPTION
Some surprisingly significant changes here. Maintaining the correspondence between NeXus properties and where they're expected in PyARPES is messy in part because runtime data formats distinguish between coordinates, attributes, etc, while on-disk archival formats mostly treat everything equally as "data" or "metadata".

I introduced `Target` which does attribute binding and you can selectively put individual pieces of metadata or data from an HDF or NeXus file in coordinates or attributes (or print it. very helpful).

In ANTARES scans are stopped early, it looks like the DAQ code leaves the raw actuator names in place instead of replacing them with meaningful ones. We can't fix this directly but at least we can prevent *duplicate* names.

Overall this should be much simpler for people to extend. In particular, adding new property bindings is very straightforward.